### PR TITLE
Improve handling of missing market data

### DIFF
--- a/data.py
+++ b/data.py
@@ -4,12 +4,32 @@ import yfinance as yf
 from datetime import datetime, timedelta, timezone
 
 def download_ohlc(ticker: str, interval: str = "15m", history_days: int = 60) -> pd.DataFrame:
-    # yfinance supports period keyword for intraday
+    """Download OHLC data for *ticker*.
+
+    The public CI environment used for kata style exercises does not have
+    unrestricted internet access.  When the download fails yfinance returns an
+    empty frame, which later causes shape errors once we try to scale features.
+    It is much more helpful to surface that situation explicitly so callers can
+    decide whether to supply cached data or simply skip the run.
+    """
+
+    # yfinance supports the period keyword for intraday data.
     period = f"{history_days}d"
-    df = yf.download(tickers=ticker, interval=interval, period=period, auto_adjust=True, prepost=False)
-    #df = df.rename(columns=str.title)  # Ensure 'Open','High','Low','Close','Volume'
-    #df = df.dropna(inplace=True)
-    #df.index = pd.to_datetime(df.index, utc=True)
+    df = yf.download(
+        tickers=ticker,
+        interval=interval,
+        period=period,
+        auto_adjust=True,
+        prepost=False,
+    )
+
+    if df.empty:
+        raise RuntimeError(
+            f"No OHLC data was retrieved for '{ticker}' with interval '{interval}'. "
+            "This is usually caused by the upstream data service being "
+            "unreachable in the current environment."
+        )
+
     return df
 
 def add_time_features(df: pd.DataFrame) -> pd.DataFrame:

--- a/features.py
+++ b/features.py
@@ -54,7 +54,8 @@ def build_feature_frame(df: pd.DataFrame) -> pd.DataFrame:
    # }, index=df.index)
 
     feats = df.copy()
-    feats.dropna()
+    # Ensure we do not keep the initial NaN rows introduced by technical indicators.
+    feats = feats.dropna()
     return feats
 
 def make_supervised(feats: pd.DataFrame, lookback: int, horizon: int):

--- a/pipeline.py
+++ b/pipeline.py
@@ -12,6 +12,14 @@ def prepare_data(ticker: str, interval: str, lookback: int, history_days: int, h
     raw = download_ohlc(ticker, interval, history_days)
     feats = build_feature_frame(raw)
     X, y, idx = make_supervised(feats, lookback, horizon)
+
+    if X.size == 0 or y.size == 0:
+        raise ValueError(
+            "The generated supervised dataset is empty. "
+            "Check that the downloaded price history spans enough data points "
+            "for the configured lookback and prediction horizon."
+        )
+
     return raw, feats, X, y, idx
 
 def train_pipeline(ticker: str, cfg, artifacts_dir: str):


### PR DESCRIPTION
## Summary
- raise a descriptive RuntimeError when yfinance returns an empty OHLC frame so data download issues are surfaced clearly
- ensure feature engineering drops the NaN rows introduced by technical indicators
- guard the training pipeline against empty supervised datasets with a helpful message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e244e97d648333b2ee40c4d46dc88f